### PR TITLE
Fix 'learner__loss' value in param_grid of basis.py

### DIFF
--- a/src/jenga/basis.py
+++ b/src/jenga/basis.py
@@ -300,7 +300,7 @@ class BinaryClassificationTask(Task):
         """
 
         param_grid = {
-            'learner__loss': ['log'],
+            'learner__loss': ['log_loss'],
             'learner__penalty': ['l2'],
             'learner__alpha': [0.00001, 0.0001, 0.001, 0.01]
         }
@@ -419,7 +419,7 @@ class MultiClassClassificationTask(Task):
         """
 
         param_grid = {
-            'learner__loss': ['log'],
+            'learner__loss': ['log_loss'],
             'learner__penalty': ['l2'],
             'learner__alpha': [0.00001, 0.0001, 0.001, 0.01]
         }


### PR DESCRIPTION
Updated the value of the 'learner__loss' key in the param_grid of basis.py. The previous value ('log') was incorrect, and was leading to the following error: "The 'loss' parameter of SGDClassifier must be a str among {'hinge', 'modified_huber', 'huber', 'squared_error', 'epsilon_insensitive', 'squared_epsilon_insensitive', 'perceptron', 'squared_hinge', 'log_loss'}. Got 'log' instead." The current value ('log_loss') works as expected.